### PR TITLE
Address test TODOs, use mock

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+pytest-mock


### PR DESCRIPTION
I cleaned up some TODO/XXX marks in the tests.py, and also brought in
pytest-mock to avoid intentionally mangling os.environ during a test
run.